### PR TITLE
DP-76: add keyboard navigation by landmarks

### DIFF
--- a/react-development-proj/src/pages/About/About.tsx
+++ b/react-development-proj/src/pages/About/About.tsx
@@ -1,19 +1,24 @@
 import MyLink from "../../components/MyLink/MyLink";
 import TitleLayout from "../../layout/TitleLayout";
+import { Navigation, Region } from "../../utils/LandmarkNav";
 
 export default function About (){
     return (
         <div role="main">
             <TitleLayout>
-                <h1>
-                    About
-                </h1>
-                <p>
-                    Information about the project will be added here in the future
-                </p>
-                <div role="navigation">
+                <Region aria-label={"About"}>
+                    <h1>
+                        About
+                    </h1>    
+                </Region>
+                <Region aria-labelledby={"About"}>
+                    <p>
+                        Information about the project will be added here in the future
+                    </p>
+                </Region>
+                <Navigation>
                     <MyLink renderAsButton={true} to="/">Home</MyLink>
-                </div>
+                </Navigation>
             </TitleLayout>
         </div>
     )

--- a/react-development-proj/src/pages/App/App.tsx
+++ b/react-development-proj/src/pages/App/App.tsx
@@ -1,18 +1,21 @@
 import './App.css'
 import TitleLayout from '../../layout/TitleLayout'
 import MyLink from '../../components/MyLink/MyLink';
+import { Navigation, Region } from '../../utils/LandmarkNav';
 
 function App() {
   return (
     <div role='main'>
       <TitleLayout>
         {/* Move these in-line styles to a CSS file? Could get messy in the future */}
+        <Region>
         <div style={{ maxWidth: "500px" }}>
           <h1 style={{ fontSize: "6.5em", textAlign: "center" }}>
             Accessible menu
           </h1>
         </div>
-        <div style={{ textAlign: "center"}} role='navigation'>
+        </Region>
+        <Navigation style={{ textAlign: "center"}}>
           <MyLink to='/About' renderAsButton={true}>
             About
           </MyLink>
@@ -22,7 +25,7 @@ function App() {
           <MyLink to='/Credits' renderAsButton={true}>
             Credits
           </MyLink>
-        </div>
+        </Navigation>
       </TitleLayout>
     </div>
   );

--- a/react-development-proj/src/pages/Config/Config.tsx
+++ b/react-development-proj/src/pages/Config/Config.tsx
@@ -1,20 +1,25 @@
 import MyLink from "../../components/MyLink/MyLink";
 import TextToSpeechToggle from "../../components/TextToSpeechToggle";
 import TitleLayout from "../../layout/TitleLayout";
+import { Navigation, Region } from "../../utils/LandmarkNav";
 
 export default function Config (){
     return (
         <div role="main">
             <TitleLayout>
-                <h1>
-                    Config
-                </h1>
-                <p>Different configuration options are provided here</p>
+                <Region aria-label="Config">
+                    <h1>
+                        Config
+                    </h1>
+                </Region>
+                <Region aria-labelledby="Config">
+                    <p>Different configuration options are provided here</p>
+                </Region>
                 <TextToSpeechToggle/>
                 <br/>
-                <div role="navigation">
+                <Navigation>
                     <MyLink renderAsButton={true} to="/">Home</MyLink>
-                </div>
+                </Navigation>
             </TitleLayout>
         </div>
     )

--- a/react-development-proj/src/pages/Credits/Credits.tsx
+++ b/react-development-proj/src/pages/Credits/Credits.tsx
@@ -1,19 +1,24 @@
 import MyLink from "../../components/MyLink/MyLink";
 import TitleLayout from "../../layout/TitleLayout";
+import { Navigation, Region } from "../../utils/LandmarkNav";
 
 export default function Credits (){
     return (
         <div role="main">
             <TitleLayout>
-                <h1>
-                    Credits
-                </h1>
-                <p>
-                    Credits will be added here in the future
-                </p>
-                <div role="navigation">
+                <Region aria-label="Credits">
+                    <h1>
+                        Credits
+                    </h1>
+                </Region>
+                <Region aria-labelledby="Credits">
+                    <p>
+                        Credits will be added here in the future
+                    </p>
+                </Region>
+                <Navigation>
                     <MyLink renderAsButton={true} to="/">Home</MyLink>
-                </div>
+                </Navigation>
             </TitleLayout>
         </div>
     )

--- a/react-development-proj/src/utils/LandmarkNav.tsx
+++ b/react-development-proj/src/utils/LandmarkNav.tsx
@@ -1,0 +1,26 @@
+import { useLandmark } from "@react-aria/landmark";
+import { useRef } from "react";
+
+export function Navigation(props: any) {
+    let ref = useRef<HTMLElement | null>(null);
+    let {landmarkProps} = useLandmark({...props, role: 'navigation'}, ref);
+
+    return (
+        <nav ref={ref} {...props} {...landmarkProps}>
+        {props.children}
+        </nav>
+    )
+}
+
+export function Region(props: any) {
+    let ref = useRef<HTMLElement | null>(null);
+    let {landmarkProps} = useLandmark({...props, role: 'region'}, ref);
+
+    return (
+        <div ref={ref} {...props} {...landmarkProps}>
+        {props.children}
+        {/* {console.log(props.children.props.children.type)}
+        {console.log(props.children.props.children.props.children)} */}
+        </div>
+    );
+}


### PR DESCRIPTION
**Description**
- use useLandmark library to add keyboard navigation by landmarks
- This should hopefully allow the narrator to read screen text in the future

**Summary of changes**
- install useLandmark
- add landmarks to all pages, navigable with F6

**Important things to note:**
- There are a lot of rules when it comes to landmarks, these should be carefully taken into consideration
- For example, landmarks are meant to be used sparingly, currently we use them quite a bit
- Voice for text is still not currently implemented